### PR TITLE
fix: Resolve font metadata paths through kpse

### DIFF
--- a/tex/neanestex.lua
+++ b/tex/neanestex.lua
@@ -45,7 +45,8 @@ local function load_font_data(font)
         font_metadata_filename = neume_font_metadata_file_map_default[font]
     end
 
-    local font_metadata = json.tolua(read_json(font_metadata_filename))
+    local font_metadata_path = kpse.find_file(font_metadata_filename, "tex") or font_metadata_filename
+    local font_metadata = json.tolua(read_json(font_metadata_path))
 
     local glyph_name_to_codepoint_map = {}
 


### PR DESCRIPTION
This PR updates NeanesTeX to resolve neume font metadata JSON files through Kpathsea, following the pattern used elsewhere in the same file. If Kpathsea doesn't find the file, we fall back to the existing behavior of reading the file from the current directory.