### PR TITLE
fix: Fix colors in TeX

### DIFF
--- a/tex/neanestex.lua
+++ b/tex/neanestex.lua
@@ -621,7 +621,7 @@ end
 local function print_note(note, pageSetup)
     tex.sprint("\\mbox{")
     tex.sprint(string.format("\\hspace{%fbp}", note.x))
-    tex.sprint(string.format("\\makebox[%fbp]{\\fontsize{\\byzneumesize}{\\baselineskip}\\byzneumefont", note.width))
+    tex.sprint(string.format("\\makebox[%fbp]{\\textcolor{byzcolorneume}{\\fontsize{\\byzneumesize}{\\baselineskip}\\byzneumefont", note.width))
 
     if note.measureBarLeft and not string.match(note.measureBarLeft, "Above$") then
         print_measure_bar(note.measureBarLeft, note.computedMeasureBarLeftOffsetX, 0, note.computedMeasureBarLeftLeadingSpacing, note.measureBarLeftOffset)
@@ -734,14 +734,25 @@ local function print_note(note, pageSetup)
     end
 
     -- Print the main neume
-    tex.sprint(string.format('\\char"%s', glyphNameToCodepointMap[note.quantitativeNeume]))
+    if note.quantitativeNeume == "breath" then
+        tex.sprint(string.format('\\textcolor{byzcolorbreath}{\\char"%s}', glyphNameToCodepointMap[note.quantitativeNeume]))
+    elseif note.quantitativeNeume == "stavros" then
+        tex.sprint(string.format('\\textcolor{byzcolorcross}{\\char"%s}', glyphNameToCodepointMap[note.quantitativeNeume]))
+    else
+        tex.sprint(string.format('\\char"%s', glyphNameToCodepointMap[note.quantitativeNeume]))
+    end
 
     if note.stavros and not note.stavrosOffset then
         tex.sprint(string.format('\\textcolor{byzcolorcross}{\\char"%s}', glyphNameToCodepointMap["stavrosAbove"]))
     end
 
     if note.vocalExpression then
-        tex.sprint(string.format('\\char"%s', glyphNameToCodepointMap[note.vocalExpression]))
+        local vocal_expression_base = string.match(note.vocalExpression, "^[^.]+")
+        if vocal_expression_base == "heteron" or vocal_expression_base == "heteronConnecting" or vocal_expression_base == "endofonon" then
+            tex.sprint(string.format('\\textcolor{byzcolorheteron}{\\char"%s}', glyphNameToCodepointMap[note.vocalExpression]))
+        else
+            tex.sprint(string.format('\\char"%s', glyphNameToCodepointMap[note.vocalExpression]))
+        end
     end
 
     -- If the user did not specify an additional offset, latex+luacolor will position the marks correctly
@@ -810,8 +821,8 @@ local function print_note(note, pageSetup)
         print_measure_bar(note.measureBarRight, note.computedMeasureBarRightOffsetX, note.computedMeasureBarRightTrailingSpacing, 0, note.measureBarRightOffset)
     end
 
-    -- close \makebox{}
-    tex.sprint("}")
+    -- close \textcolor{} and \makebox{}
+    tex.sprint("}}")
 
     -- Neanes positions a transferred right measure bar absolutely at the end
     -- of the note box, so it must not affect the box width or lyric centering.
@@ -910,7 +921,7 @@ local function print_martyria(martyria, pageSetup)
     tex.sprint(string.format('\\char"%s\\char"%s', glyphNameToCodepointMap[martyria.note], glyphNameToCodepointMap[martyria.rootSign]))
 
     if martyria.fthora then
-        tex.sprint(string.format('\\textcolor{byzcolormartyria}{\\char"%s}', glyphNameToCodepointMap[martyria.fthora]))
+        tex.sprint(string.format('\\textcolor{byzcolorfthora}{\\char"%s}', glyphNameToCodepointMap[martyria.fthora]))
     end
 
     if martyria.tempo then
@@ -1030,7 +1041,7 @@ local function print_mode_key(modeKey, pageSetup)
         tex.sprint(string.format('\\char"%s', glyphNameToCodepointMap[modeKey.fthoraAboveQuantitativeNeumeRight]))
     end
     if modeKey.tempo and not modeKey.tempoAlignRight then
-        tex.sprint(string.format('\\hspace{6bp}\\raisebox{0.45em}{\\char"%s}', glyphNameToCodepointMap[modeKey.tempo]))
+        tex.sprint(string.format('\\hspace{6bp}\\raisebox{0.45em}{\\textcolor{byzcolortempo}{\\char"%s}}', glyphNameToCodepointMap[modeKey.tempo]))
     end
 
     -- end \textcolor and \makebox
@@ -1044,7 +1055,7 @@ local function print_mode_key(modeKey, pageSetup)
         if modeKey.showAmbitus then
             tex.sprint(
                 string.format(
-                    '\\raisebox{3bp}{{\\sffamily{}(}\\raisebox{0.45em}{\\char"%s\\char"%s}\\hspace{7.5bp}{\\sffamily{}-}\\hspace{1.5bp}\\raisebox{0.45em}{\\char"%s\\char"%s}\\hspace{3bp}{\\sffamily{})}}',
+                    '\\raisebox{3bp}{{\\sffamily{}(}\\raisebox{0.45em}{\\textcolor{byzcolormartyria}{\\char"%s\\char"%s}}\\hspace{7.5bp}{\\sffamily{}-}\\hspace{1.5bp}\\raisebox{0.45em}{\\textcolor{byzcolormartyria}{\\char"%s\\char"%s}}\\hspace{3bp}{\\sffamily{})}}',
                     glyphNameToCodepointMap[modeKey.ambitusLowNote],
                     glyphNameToCodepointMap[modeKey.ambitusLowRootSign],
                     glyphNameToCodepointMap[modeKey.ambitusHighNote],
@@ -1058,7 +1069,7 @@ local function print_mode_key(modeKey, pageSetup)
         end
 
         if modeKey.tempo and modeKey.tempoAlignRight then
-            tex.sprint(string.format('\\raisebox{0.45em}{\\char"%s}', glyphNameToCodepointMap[modeKey.tempo]))
+            tex.sprint(string.format('\\raisebox{0.45em}{\\textcolor{byzcolortempo}{\\char"%s}}', glyphNameToCodepointMap[modeKey.tempo]))
         end
 
         -- end \textcolor and \makebox
@@ -1252,6 +1263,8 @@ local function include_score(filename, sectionName)
     tex.sprint(string.format("\\setlength{\\baselineskip}{%fbp}", data.pageSetup.lineHeight))
 
     tex.sprint(string.format("\\definecolor{byzcoloraccidental}{HTML}{%s}", data.pageSetup.colors.accidental))
+    tex.sprint(string.format("\\definecolor{byzcolorbreath}{HTML}{%s}", data.pageSetup.colors.breath or data.pageSetup.colors.neume))
+    tex.sprint(string.format("\\definecolor{byzcolorcross}{HTML}{%s}", data.pageSetup.colors.cross or data.pageSetup.colors.neume))
     tex.sprint(string.format("\\definecolor{byzcolorfthora}{HTML}{%s}", data.pageSetup.colors.fthora))
     tex.sprint(string.format("\\definecolor{byzcolorgorgon}{HTML}{%s}", data.pageSetup.colors.gorgon))
     tex.sprint(string.format("\\definecolor{byzcolorheteron}{HTML}{%s}", data.pageSetup.colors.heteron))

--- a/tex/neanestex.sty
+++ b/tex/neanestex.sty
@@ -24,6 +24,8 @@
 
 % Colors
 \definecolor{byzcoloraccidental}{HTML}{ED0000}
+\definecolor{byzcolorbreath}{HTML}{000000}
+\definecolor{byzcolorcross}{HTML}{000000}
 \definecolor{byzcolorfthora}{HTML}{ED0000}
 \definecolor{byzcolorgorgon}{HTML}{ED0000}
 \definecolor{byzcolorheteron}{HTML}{ED0000}


### PR DESCRIPTION
This change expands color support in the TeX renderer so that Byzantine notation symbols use the color categories provided by the score's page setup. Notes now inherit the configured neume color by default, while breaths, crosses, selected vocal expressions, fthoras, and tempos can use their own dedicated colors.

## Motivation

Several notation elements were previously emitted without a color wrapper or with the wrong color category. As a result, exported scores could not fully reproduce the color configuration defined by Neanes, and some symbols inherited an unrelated surrounding color. In particular, martyria fthoras used the martyria color instead of the fthora color, while mode-key tempo marks did not use the configured tempo color.

## Changes

- Wrap each note's notation box in `byzcolorneume` so ordinary neumes and related symbols inherit the configured neume color.
- Render a quantitative `breath` with `byzcolorbreath`.
- Render a quantitative `stavros` and an above-note stavros with `byzcolorcross`.
- Render `heteron`, `heteronConnecting`, and `endofonon` vocal-expression variants with `byzcolorheteron`, including glyph names that contain a variant suffix.
- Render martyria fthoras with `byzcolorfthora` instead of `byzcolormartyria`.
- Render both left-aligned and right-aligned mode-key tempo marks with `byzcolortempo`.
- Define `byzcolorbreath` and `byzcolorcross` when a score is loaded. If older score data does not provide these fields, both colors fall back to the configured neume color.
- Add black default definitions for `byzcolorbreath` and `byzcolorcross` to the package stylesheet.

## Implementation details

The note-level `\makebox` now contains a `\textcolor{byzcolorneume}` wrapper. More specific symbol categories add nested color wrappers, allowing them to override the note color without changing positioning, box width, lyric centering, or measure-bar handling.

Vocal-expression glyph names are normalized to the portion before the first period when selecting a color category. This applies the heteron color consistently to suffixed glyph variants while preserving the full glyph name for codepoint lookup.

The new breath and cross page-setup fields are optional for backward compatibility. Scores produced before those fields were introduced continue to render by inheriting the neume color.