### PR TITLE
fix: Scope text line height to block text boxes

### DIFF
--- a/tex/neanestex.lua
+++ b/tex/neanestex.lua
@@ -492,30 +492,34 @@ local function style_color_command(style, command)
     return style.color and string.format("%s[HTML]{%s}", command, style.color) or command .. "{black}"
 end
 
-local function style_leading(style)
+-- Keep shared font setup independent of paragraph line height. Lyrics, drop
+-- caps, and inline text boxes are positioned by their element geometry; only
+-- block text boxes use paragraph leading.
+local function style_font_setup(style)
+    local size = style.fontSize
+    assert(type(size) == "number", "Text style fontSize must be a number")
+
+    return string.format("\\fontsize{%fbp}{%fbp}", size, size * 1.2)
+end
+
+-- Neanes applies paragraph-style line height only to non-inline text boxes.
+local function text_box_font_setup(style)
     local line_height = style.lineHeight
 
     if line_height == nil or line_height == "normal" then
-        return style.fontSize * 1.2
+        return style_font_setup(style)
     end
 
     if type(line_height) ~= "number" or line_height ~= line_height or line_height < 0 or line_height >= math.huge then
         error(string.format('Text style "%s" lineHeight must be a non-negative number or "normal"; got %s', tostring(style.id), tostring(line_height)))
     end
 
-    return style.fontSize * line_height
-end
-
--- Paragraph leading belongs to the text style. The score-wide \baselineskip is
--- staff spacing and must not leak into text elements. The size and leading
--- travel together so every styled element selects both through this fragment.
-local function style_font_setup(style)
     local size = style.fontSize
     assert(type(size) == "number", "Text style fontSize must be a number")
 
     -- TeX otherwise replaces small or overlapping leading (including zero)
     -- with \lineskip. Keep the requested baseline distance authoritative.
-    return string.format("\\fontsize{%fbp}{%fbp}\\lineskiplimit=-\\maxdimen", size, style_leading(style))
+    return string.format("\\fontsize{%fbp}{%fbp}\\lineskiplimit=-\\maxdimen", size, size * line_height)
 end
 
 -- The style an element renders in, or nil for one that prints no text. Classify
@@ -1109,22 +1113,16 @@ local function print_text_box_inline(textBox)
     local style = textBox.resolved_style
     local color = style_color_command(style, "\\textcolor")
     local position = alignment_position(style.alignment)
-    local content = decorate_content(escape_latex(textBox.content), style)
+    local content = styled_content(textBox.content, style)
 
     if textBox.contentBottom and textBox.contentBottom ~= "" then
-        local left_fill = position == "l" and "" or "\\hss"
-        local right_fill = position == "r" and "" or "\\hss"
-        local bottom = decorate_content(escape_latex(textBox.contentBottom), style)
-
-        -- \shortstack hardcodes its own interline settings. Consecutive hboxes
-        -- in a vbox use the leading installed by style_font_setup instead.
-        content = string.format("\\vbox{\\hbox to %fbp{%s%s%s}\\hbox to %fbp{%s%s%s}}", textBox.width, left_fill, content, right_fill, textBox.width, left_fill, bottom, right_fill)
+        content = string.format("\\shortstack[%s]{%s\\\\%s}", position, content, styled_content(textBox.contentBottom, style))
     end
 
     tex.sprint("\\mbox{")
     tex.sprint(string.format("\\hspace{%fbp}", textBox.x))
     tex.sprint(string.format("\\makebox[%fbp][%s]{", textBox.width, position))
-    tex.sprint(string.format("%s{%s%s%s", color, style_font_setup(style), font_selection(style), content))
+    tex.sprint(string.format("%s{%s%s", color, style_font_setup(style), content))
 
     -- end \textcolor and \makebox
     tex.sprint("}}")
@@ -1158,9 +1156,9 @@ local function print_text_box(textBox)
     if textBox.multipanel then
         content = string.format(
             "\\makebox[\\linewidth][l]{%s}\\hspace{-\\linewidth}\\makebox[\\linewidth][c]{%s}\\hspace{-\\linewidth}\\makebox[\\linewidth][r]{%s}",
-            styled_content(textBox.contentLeft or "", style),
-            styled_content(textBox.contentCenter or "", style),
-            styled_content(textBox.contentRight or "", style)
+            decorate_content(escape_latex(textBox.contentLeft or ""), style),
+            decorate_content(escape_latex(textBox.contentCenter or ""), style),
+            decorate_content(escape_latex(textBox.contentRight or ""), style)
         )
     else
         content = decorate_content(escape_latex(textBox.content), style)
@@ -1184,16 +1182,8 @@ local function print_text_box(textBox)
         tex.sprint("\\raggedright")
     end
 
-    tex.sprint(string.format("%s{%s", color, style_font_setup(style)))
-
-    if textBox.multipanel then
-        tex.sprint(content)
-    else
-        -- Keep the selected font in scope until \par builds every line and
-        -- inserts the style's requested baseline glue.
-        tex.sprint(font_selection(style))
-        tex.sprint(content)
-    end
+    -- Keep the selected font and leading in scope until \par builds every line.
+    tex.sprint(string.format("%s{%s%s%s", color, text_box_font_setup(style), font_selection(style), content))
 
     -- End the paragraph while its text leading is still in scope, then close
     -- \color and \parbox.


### PR DESCRIPTION
Amends #10. Match Neanes production layout semantics for paragraph-style line height. Lyrics use measured font metrics, while inline text boxes and drop caps rely on exported element geometry rather than paragraph leading. Restore conventional leading in the shared font setup and bring back shortstack for inline top/bottom content. This removes the custom vbox/hbox construction and keeps lyric, drop-cap, and inline TeX output compact. Retain numeric line-height support for non-inline text boxes. Keep the selected font and leading in scope through paragraph construction, preserve zero and overlapping leading, and share the outer font selection across multipanel content.